### PR TITLE
Monadic

### DIFF
--- a/src/vow.re
+++ b/src/vow.re
@@ -42,6 +42,8 @@ module type ResultType = {
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
     let (=<<): ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
+    let (>>|): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
+    let (|<<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   };
 };
 
@@ -82,6 +84,8 @@ module Result: ResultType = {
   module Infix = {
     let (>>=) v t => flatMap t v;
     let (=<<) = flatMap;
+    let (>>|) v t => map t v;
+    let (|<<) = map;
   };
 };
 

--- a/src/vow.re
+++ b/src/vow.re
@@ -45,9 +45,7 @@ module type ResultType = {
     vow 'a 'status;
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
-    let (=<<): ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
     let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
-    let (=|<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   };
 };
 
@@ -98,9 +96,7 @@ module Result: ResultType = {
   let unwrap transform vow => Vow.bind transform vow;
   module Infix = {
     let (>>=) v t => bind t v;
-    let (=<<) = bind;
     let (>|=) v t => map t v;
-    let (=|<) = map;
   };
 };
 

--- a/src/vow.re
+++ b/src/vow.re
@@ -45,7 +45,7 @@ module type ResultType = {
     vow 'a 'status;
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
-    let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
+    let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error handled;
   };
 };
 

--- a/src/vow.re
+++ b/src/vow.re
@@ -46,8 +46,8 @@ module type ResultType = {
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
     let (=<<): ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
-    let (>>|): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
-    let (|<<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
+    let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
+    let (=|<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   };
 };
 
@@ -99,8 +99,8 @@ module Result: ResultType = {
   module Infix = {
     let (>>=) v t => bind t v;
     let (=<<) = bind;
-    let (>>|) v t => map t v;
-    let (|<<) = map;
+    let (>|=) v t => map t v;
+    let (=|<) = map;
   };
 };
 

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -14,14 +14,14 @@ let return: 'a => t 'a handled;
 /**
  * Maps a handled vow with value of type 'a to a vow returned by the transform function
  */
-let flatMap: ('a => t 'b 'status) => t 'a handled => t 'b 'status;
+let bind: ('a => t 'b 'status) => t 'a handled => t 'b 'status;
 
 
 /**
  * Maps an unhandled vow with value of type 'a to a vow returned by the transform function.
  * The returned vow is unhandled.
  */
-let flatMapUnhandled: ('a => t 'b 'status) => t 'a unhandled => t 'b unhandled;
+let bindUnhandled: ('a => t 'b 'status) => t 'a unhandled => t 'b unhandled;
 
 
 /**
@@ -75,9 +75,8 @@ module type ResultType = {
   type t 'value 'error 'status = vow (result 'value 'error) 'status;
   let return: 'value => t 'value 'error handled;
   let fail: 'error => t 'value 'error handled;
-  let flatMap: ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
-  let flatMapUnhandled:
-    ('a => t 'b 'error 'status) => t 'a 'error unhandled => t 'b 'error unhandled;
+  let bind: ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
+  let bindUnhandled: ('a => t 'b 'error 'status) => t 'a 'error unhandled => t 'b 'error unhandled;
   let map: ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   let mapUnhandled: ('a => 'b) => t 'a 'error unhandled => t 'b 'error unhandled;
   let mapError: ('a => t 'value 'b handled) => t 'value 'a 'status => t 'value 'b 'status;

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -90,9 +90,7 @@ module type ResultType = {
     vow 'a 'status;
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
-    let (=<<): ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
     let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
-    let (=|<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   };
 };
 

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -91,8 +91,8 @@ module type ResultType = {
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
     let (=<<): ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
-    let (>>|): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
-    let (|<<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
+    let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
+    let (=|<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   };
 };
 

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -87,6 +87,8 @@ module type ResultType = {
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
     let (=<<): ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
+    let (>>|): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
+    let (|<<): ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   };
 };
 

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -14,14 +14,14 @@ let return: 'a => t 'a handled;
 /**
  * Maps a handled vow with value of type 'a to a vow returned by the transform function
  */
-let bind: ('a => t 'b 'status) => t 'a handled => t 'b 'status;
+let flatMap: ('a => t 'b 'status) => t 'a handled => t 'b 'status;
 
 
 /**
  * Maps an unhandled vow with value of type 'a to a vow returned by the transform function.
  * The returned vow is unhandled.
  */
-let bindUnhandled: ('a => t 'b 'status) => t 'a unhandled => t 'b unhandled;
+let flatMapUnhandled: ('a => t 'b 'status) => t 'a unhandled => t 'b unhandled;
 
 
 /**
@@ -75,8 +75,8 @@ module type ResultType = {
   type t 'value 'error 'status = vow (result 'value 'error) 'status;
   let return: 'value => t 'value 'error handled;
   let fail: 'error => t 'value 'error handled;
-  let bind: ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
-  let bindUnhandled: ('a => t 'b 'error 'status) => t 'a 'error unhandled => t 'b 'error unhandled;
+  let flatMap: ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
+  let flatMapUnhandled: ('a => t 'b 'error 'status) => t 'a 'error unhandled => t 'b 'error unhandled;
   let map: ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
   let mapUnhandled: ('a => 'b) => t 'a 'error unhandled => t 'b 'error unhandled;
   let mapError: ('a => t 'value 'b handled) => t 'value 'a 'status => t 'value 'b 'status;

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -14,14 +14,28 @@ let return: 'a => t 'a handled;
 /**
  * Maps a handled vow with value of type 'a to a vow returned by the transform function
  */
-let map: ('a => t 'b 'status) => t 'a handled => t 'b 'status;
+let flatMap: ('a => t 'b 'status) => t 'a handled => t 'b 'status;
 
 
 /**
  * Maps an unhandled vow with value of type 'a to a vow returned by the transform function.
  * The returned vow is unhandled.
  */
-let mapUnhandled: ('a => t 'b 'status) => t 'a unhandled => t 'b unhandled;
+let flatMapUnhandled: ('a => t 'b 'status) => t 'a unhandled => t 'b unhandled;
+
+
+/**
+ * Maps a handled vow with value of type 'a to a vow of the value
+ * returned by the transform function
+ */
+let map: ('a => 'b) => t 'a handled => t 'b 'status;
+
+
+/**
+ * Maps a handled vow with value of type 'a to a vow of the value
+ * returned by the transform function
+ */
+let mapUnhandled: ('a => 'b) => t 'a unhandled => t 'b unhandled;
 
 
 /**
@@ -61,8 +75,11 @@ module type ResultType = {
   type t 'value 'error 'status = vow (result 'value 'error) 'status;
   let return: 'value => t 'value 'error handled;
   let fail: 'error => t 'value 'error handled;
-  let map: ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
-  let mapUnhandled: ('a => t 'b 'error 'status) => t 'a 'error unhandled => t 'b 'error unhandled;
+  let flatMap: ('a => t 'b 'error 'status) => t 'a 'error handled => t 'b 'error 'status;
+  let flatMapUnhandled:
+    ('a => t 'b 'error 'status) => t 'a 'error unhandled => t 'b 'error unhandled;
+  let map: ('a => 'b) => t 'a 'error handled => t 'b 'error 'status;
+  let mapUnhandled: ('a => 'b) => t 'a 'error unhandled => t 'b 'error unhandled;
   let sideEffect: ([ | `Success 'value | `Fail 'error] => unit) => t 'value 'error handled => unit;
   let onError:
     (unit => t 'error 'value 'status) => t 'error 'value unhandled => t 'error 'value 'status;

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -90,7 +90,7 @@ module type ResultType = {
     vow 'a 'status;
   module Infix: {
     let (>>=): t 'a 'error handled => ('a => t 'b 'error 'status) => t 'b 'error 'status';
-    let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error 'status;
+    let (>|=): t 'a 'error handled => ('a => 'b) => t 'b 'error handled;
   };
 };
 


### PR DESCRIPTION
This changes `map` to be what is usually expected of a monadic interface, and introduces `flatMap` as a new name for the previous `map` function.

This is a breaking change. We should probably handle the versioning accordingly.