### PR TITLE
Sound containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 lib
 .merlin
+.bsb.lock

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -5,6 +5,10 @@
     "-bs-super-errors"
   ],
   "sources": [
-    "src"
+    "src",
+    {
+      "dir": "tests",
+      "type": "dev"
+    }
   ]
 }

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -21,7 +21,8 @@ let flatMap: ('a => t('b, 'status), t('a, handled)) => t('b, 'status);
  * Maps an unhandled vow with value of type 'a to a vow returned by the transform function.
  * The returned vow is unhandled.
  */
-let flatMapUnhandled: ('a => t('b, 'status), t('a, unhandled)) => t('b, unhandled);
+let flatMapUnhandled:
+  ('a => t('b, 'status), t('a, unhandled)) => t('b, unhandled);
 
 
 /***
@@ -63,11 +64,13 @@ let wrap: Js.Promise.t('a) => t('a, unhandled);
  */
 let unsafeWrap: Js.Promise.t('a) => t('a, handled);
 
+type container('a) = {value: 'a};
+
 
 /***
  * Returns the underlying JS Promise.
  */
-let unwrap: t('a, handled) => Js.Promise.t('a);
+let unwrap: t('a, handled) => Js.Promise.t(container('a));
 
 module type ResultType = {
   type result('value, 'error);
@@ -75,23 +78,39 @@ module type ResultType = {
   type t('value, 'error, 'status) = vow(result('value, 'error), 'status);
   let return: 'value => t('value, 'error, handled);
   let fail: 'error => t('value, 'error, handled);
-  let flatMap: ('a => t('b, 'error, 'status), t('a, 'error, handled)) => t('b, 'error, 'status);
+  let flatMap:
+    ('a => t('b, 'error, 'status), t('a, 'error, handled)) =>
+    t('b, 'error, 'status);
   let flatMapUnhandled:
-    ('a => t('b, 'error, 'status), t('a, 'error, unhandled)) => t('b, 'error, unhandled);
+    ('a => t('b, 'error, 'status), t('a, 'error, unhandled)) =>
+    t('b, 'error, unhandled);
   let map: ('a => 'b, t('a, 'error, handled)) => t('b, 'error, 'status);
-  let mapUnhandled: ('a => 'b, t('a, 'error, unhandled)) => t('b, 'error, unhandled);
-  let mapError: ('a => t('value, 'b, handled), t('value, 'a, 'status)) => t('value, 'b, 'status);
+  let mapUnhandled:
+    ('a => 'b, t('a, 'error, unhandled)) => t('b, 'error, unhandled);
+  let mapError:
+    ('a => t('value, 'b, handled), t('value, 'a, 'status)) =>
+    t('value, 'b, 'status);
   let sideEffect:
-    ([ | `Success('value) | `Fail('error)] => unit, t('value, 'error, handled)) => unit;
+    (
+      [ | `Success('value) | `Fail('error)] => unit,
+      t('value, 'error, handled)
+    ) =>
+    unit;
   let onError:
     (unit => t('error, 'value, 'status), t('error, 'value, unhandled)) =>
     t('error, 'value, 'status);
-  let wrap: (Js.Promise.t('value), unit => 'error) => t('value, 'error, handled);
+  let wrap:
+    (Js.Promise.t('value), unit => 'error) => t('value, 'error, handled);
   let unwrap:
-    ([ | `Success('value) | `Fail('error)] => vow('a, 'status), t('value, 'error, handled)) =>
+    (
+      [ | `Success('value) | `Fail('error)] => vow('a, 'status),
+      t('value, 'error, handled)
+    ) =>
     vow('a, 'status);
   module Infix: {
-    let (>>=): (t('a, 'error, handled), 'a => t('b, 'error, 'status)) => t('b, 'error, 'status');
+    let (>>=):
+      (t('a, 'error, handled), 'a => t('b, 'error, 'status)) =>
+      t('b, 'error, 'status');
     let (>|=): (t('a, 'error, handled), 'a => 'b) => t('b, 'error, handled);
   };
 };

--- a/tests/soundness_tests.re
+++ b/tests/soundness_tests.re
@@ -1,0 +1,28 @@
+Vow.return("hello") |> Vow.sideEffect(Js.log);
+
+/* Vow inside vow */
+Vow.return(Vow.return("hello"))
+|> Vow.sideEffect(x => x |> Vow.sideEffect(Js.log));
+
+/* Promise inside vow */
+Vow.return(Js.Promise.resolve("hello"))
+|> Vow.sideEffect(r =>
+     Js.Promise.then_(str => Js.Promise.resolve(Js.log(str)), r) |> ignore
+   );
+
+Vow.return(Js.Promise.resolve("hello"))
+|> Vow.map(Js.Promise.then_(str => Js.Promise.resolve(str ++ " world")))
+|> Vow.map(r => Js.Promise.then_(str => Js.Promise.resolve(Js.log(str)), r));
+
+/* Vow inside promise */
+Js.Promise.resolve(Vow.return("hello"))
+|> Js.Promise.then_(strVow =>
+     Js.Promise.resolve(Vow.sideEffect(Js.log, strVow))
+   );
+
+Vow.return(Js.Promise.resolve("unwrapping"))
+|> Vow.unwrap
+|> Js.Promise.then_((promise: Vow.container(_)) =>
+     Js.Promise.then_(x => Js.log(x) |> Js.Promise.resolve, promise.value)
+   )
+|> ignore;


### PR DESCRIPTION
Added an inner wrapper to ensure that all possible cases of unsoundness are handled:
- A Vow inside a promise
- A Promise inside a vow
- A Vow inside a Vow

(Of course it is impossible to handle the case of Promise inside Promise unless monkey patching is applied, though this would break a great many dependencies were this were to happen)

> Note: all of the code changes are constrained to the Vow module and interface thereof. All other changes are superficial and a result of refmt and merlin in vscode. I can eliminate these changes if necessary.