### PR TITLE
Add `tap` and `tapError`

### DIFF
--- a/src/vow.re
+++ b/src/vow.re
@@ -129,6 +129,13 @@ module type ResultType = {
     t(('v1, 'v2, 'v3, 'v4), 'error, handled);
   let all:
     list(t('value, 'error, handled)) => t(list('value), 'error, handled);
+  let tap:
+    ('value => unit, t('value, 'error, handled)) =>
+    t('value, 'error, 'status);
+  let tapError:
+    ('error => unit, t('value, 'error, handled)) =>
+    t('value, 'error, 'status);
+
   module Infix: {
     let (>>=):
       (t('a, 'error, handled), 'a => t('b, 'error, 'status)) =>
@@ -207,6 +214,19 @@ module Result: ResultType = {
          )
     | [] => return([])
     };
+  let tap = (fn, vow) =>
+    vow
+    |> flatMap(value => {
+         fn(value);
+         vow;
+       });
+  let tapError = (fn, vow) =>
+    vow
+    |> mapError(err => {
+         fn(err);
+         vow;
+       });
+
   module Infix = {
     let (>>=) = (v, t) => flatMap(t, v);
     let (>|=) = (v, t) => map(t, v);

--- a/src/vow.rei
+++ b/src/vow.rei
@@ -144,6 +144,13 @@ module type ResultType = {
     t(('v1, 'v2, 'v3, 'v4), 'error, handled);
   let all:
     list(t('value, 'error, handled)) => t(list('value), 'error, handled);
+  let tap:
+    ('value => unit, t('value, 'error, handled)) =>
+    t('value, 'error, 'status);
+  let tapError:
+    ('error => unit, t('value, 'error, handled)) =>
+    t('value, 'error, 'status);
+
   module Infix: {
     let (>>=):
       (t('a, 'error, handled), 'a => t('b, 'error, 'status)) =>


### PR DESCRIPTION
These are convenient functions for performing some side effect (such as
logging) on the value or error without modifying the error or consuming
the vow.